### PR TITLE
send right click to work with ssh remote python

### DIFF
--- a/Default.sublime-commands
+++ b/Default.sublime-commands
@@ -5,5 +5,9 @@
 
     {"caption": "Send to Shell: Run file",
      "command": "sendtoshell",
-     "args": {"how": "run_file"}}
+     "args": {"how": "run_file"}},
+
+    {"caption": "Send to Shell: Select shell",
+     "command": "sendtoshell",
+     "args": {"how": "select_shell"}}
 ]

--- a/SendToShell.sublime-settings
+++ b/SendToShell.sublime-settings
@@ -3,5 +3,6 @@
     "string_to_run": "%run",
     "window_title": "Windows PowerShell",
     "powershell_startup": "powershell",
-    "python_startup": "ipython"
+    "python_startup": "ipython",
+    "send_right_click": "True"
 }

--- a/sendtoshell.py
+++ b/sendtoshell.py
@@ -4,9 +4,10 @@ import subprocess
 
 try:
     import Pywin32.setup
-    from win32con import WM_KEYDOWN, WM_KEYUP, VK_RETURN, WM_CHAR
-    from win32gui import FindWindow, PostMessage
-    from win32api import SendMessage
+    from win32con import WM_KEYDOWN, WM_KEYUP, VK_RETURN, WM_CHAR, MOUSEEVENTF_RIGHTDOWN, MOUSEEVENTF_ABSOLUTE, MOUSEEVENTF_RIGHTUP, MOUSEEVENTF_ABSOLUTE
+    from win32gui import FindWindow, PostMessage, GetWindowText, GetClassName, EnumWindows, SetForegroundWindow, GetWindowRect
+    from win32api import SendMessage, mouse_event, SetCursorPos, GetCursorPos
+    from win32com.client import Dispatch
 except:
     print('Sendtoshell - win32 modules not found, ' +
           'install Pywin32 from package control')
@@ -15,8 +16,37 @@ except:
 from os import startfile
 from time import sleep
 
-
+subl_handle = None
 SETTINGS_FILE = "SendToShell.sublime-settings"
+
+
+def enum_window_titles():
+    '''
+    https://stackoverflow.com/a/11511682/566035
+    with modification to return a dict of {handle: (title, classname)}
+    '''
+    def callback(handle, data):
+        title = GetWindowText(handle)
+        classname = GetClassName(handle)
+        if title:
+            titles[handle] = (title, classname)
+
+    titles = dict()
+    EnumWindows(callback, None)
+    
+    return titles
+
+
+def find_suspects(view=None):
+    global subl_handle
+    suspects = []
+    titles = enum_window_titles()
+    for handle, (title, classname) in sorted(titles.items(), key=lambda x: x[1][0]):
+        if classname in ("ConsoleWindowClass", "PuTTY"): # look for cmd, wsl, PuTTy
+            suspects.append('{0}: {1}'.format(handle, title))
+        if title.endswith("- Sublime Text") and classname == "PX_WINDOW_CLASS":
+            subl_handle = int(handle) # assuming only one sublime instance
+    return suspects
 
 
 def settings():
@@ -41,10 +71,22 @@ class SendtoshellCommand(sublime_plugin.TextCommand):
         return settings().get("window_title")
 
     def run(self, edit, how):
-        self.send_to_powershell(how)
+        if how == 'select_shell' or not hasattr(self, 'selectedshell'):
+            self.suspects = find_suspects()
+            print (self.suspects)
+            self.view.show_popup_menu(self.suspects, self.on_select)
+        else:
+            self.send_to_powershell(how)
+
+    def on_select(self, index):
+        self.selectedshell = int(self.suspects[index].split(':')[0])
+        print("on_select: shell hwnd {0}, sublime hwnd {1}".format(self.selectedshell, subl_handle))
 
     def send_to_powershell(self, how):
-        hwnd = FindWindow(None, self.window_title())
+        if self.selectedshell:
+            hwnd = self.selectedshell
+        else:
+            hwnd = FindWindow(None, self.window_title())
         if hwnd == 0:
             # no window available? Try to open a new instance
             print('Sendtoshell - no powershell found, opening new')
@@ -69,9 +111,18 @@ class SendtoshellCommand(sublime_plugin.TextCommand):
                 if not region.empty():
                     # Get the selected text
                     selected_text = self.view.substr(region)
-                    print('Sendtoshell - pasting, make sure you `keyup` ' +
-                          'within 0.4 seconds!')
-                    sleep(0.4)
+                else:
+                    # If no selection, then select the current line like PyCharm or RStudio
+                    selected_text = self.view.substr(self.view.line(region))
+                    # Move the caret one line down
+                    self.view.run_command("move", {"by": "lines", "forward": True, "amount": 1})
+
+                print('Sendtoshell - pasting, make sure you `keyup` ' +
+                      'within 0.4 seconds!')
+                sleep(0.4)
+                if settings().get("send_right_click") == 'True':
+                    self._sendRclick(hwnd, selected_text)
+                else:
                     sublime.set_clipboard(selected_text)
                     self._sendmsg(hwnd, self.string_to_paste())
 
@@ -84,3 +135,50 @@ class SendtoshellCommand(sublime_plugin.TextCommand):
         PostMessage(hwnd, WM_KEYDOWN, VK_RETURN, int('0x1C0001', 0))
         PostMessage(hwnd, WM_KEYUP, VK_RETURN, int('0xC0000001', 0))
 
+    def _sendRclick(self, hwnd, msg):
+        # IPython magic %paste does not work for remote ssh python 
+        # or Windows Subsystem for Linux, so let's send right click using win32
+        def _pasting(hwnd, msg):
+                sublime.set_clipboard(msg)
+                sleep(0.1) # important!
+                # sending right-click to paste over
+                mouse_event(MOUSEEVENTF_RIGHTDOWN|MOUSEEVENTF_ABSOLUTE, 0, 0)
+                sleep(0.1) # important!
+                mouse_event(MOUSEEVENTF_RIGHTUP|MOUSEEVENTF_ABSOLUTE, 0, 0)
+                # send enter;  int('0x1C0001', 0) works both on WSL and cmd
+                PostMessage(hwnd, WM_KEYDOWN, VK_RETURN, int('0x1C0001', 0))
+                PostMessage(hwnd, WM_KEYUP, VK_RETURN, int('0xC0000001', 0))
+
+        try:
+            # https://stackoverflow.com/a/15503675/566035
+            shell = Dispatch("WScript.Shell")
+            shell.SendKeys('%') # Sending Alt key goes around windows security policy change
+            SetForegroundWindow(hwnd)
+        except:
+            self.view.show_popup('Invalid handle ({})'.format(hwnd))
+            return
+
+        # move mouse to the center of that window
+        oldx, oldy = GetCursorPos()
+        x1,y1,x2,y2 = GetWindowRect(hwnd)
+        x = int((x1+x2)/2)
+        y = int((y1+y2)/2)
+        SetCursorPos((x,y))
+        
+        lineN = len(self.view.lines(self.view.sel()[0]))
+        # we need to use %cpaste magic to avoid indentation error
+        # in case more than 2 lines have indentation.
+        if lineN > 2:
+            _pasting(hwnd, "%cpaste")
+            _pasting(hwnd, msg)
+            _pasting(hwnd, "--")
+        else:
+            _pasting(hwnd, msg)
+
+        # bring back the mouse cursor
+        SetCursorPos((oldx,oldy))
+
+        # bring back the focus to sublime, if subl_handle is known to the plugin
+        if subl_handle:
+            SetForegroundWindow(subl_handle)
+            shell.SendKeys('%') # cancel the Alt key evoked menu


### PR DESCRIPTION
I wanted to use `Send-to-Shell` for PuTTy or WSL (Windows Subsystem for Linux) to work with remote python instance via ssh. But, `%paste` magic requires sharing the remote machine's clipboard (meaning x-forwarding and etc). A work around is to send right-click into the target window. This pull request suggests three changes: 

(1) a new parameter `send_right_click` in sublime-settings file. If this is set `True`, then it will use this right click method instead of the original `%paste` magic.
(2) a similar behavior like PyCharm or RStudio that when no selection was made, it will select the current line to send and after executing the line, it will push the caret one line down.
(3) a popup menu to select the target shell. The new command `select_shell` will fetch shell-like windows currently opened (cmd, PuTTy, WSL) and show the popup menu to choose the target window. Once selected, this overrides the window selection by title behavior. You might want to delete `or not hasattr(self, 'selectedshell')` in line 74 of `sendtoshell.py` as this effectively forces users to choose the target window this way.

Please feel free to decline this pull request as it added too many changes. Let me know if you think I should make a separate plugin instead... 